### PR TITLE
feat: Add compact mode to the blog

### DIFF
--- a/src/components/CompactMode/CompactControls.svelte
+++ b/src/components/CompactMode/CompactControls.svelte
@@ -1,0 +1,30 @@
+<script>
+  import { onMount } from "svelte";
+  import { Toggle } from "flowbite-svelte";
+  import { compact } from "../../stores/compact";
+
+  let mounted = false;
+  let isCompact = false;
+
+  function onToggle(ev) {
+    const { checked } = ev?.target;
+    isCompact = checked;
+    compact.set(isCompact);
+    if (typeof localStorage !== "undefined") {
+      localStorage.setItem("compact", isCompact);
+    }
+  }
+
+  onMount(() => {
+    mounted = true;
+    if (typeof localStorage !== "undefined") {
+      isCompact = localStorage.getItem("compact") === "true";
+      compact.set(isCompact);
+    }
+  });
+</script>
+
+<div class="flex items-center">
+  <span class="mr-4 text-lg text-white">Compact Mode</span>
+  <Toggle bind:checked={isCompact} on:change={onToggle} />
+</div>

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -34,8 +34,24 @@ const dateStr = new Date(frontmatter.publish_date).toLocaleString("en-US", {
 });
 ---
 
+<script>
+  import { compact } from "../stores/compact";
+  compact.subscribe((value) => {
+    if (typeof document !== "undefined") {
+      document.body.classList.toggle("compact", value);
+    }
+  });
+</script>
+
+<style is:global>
+  body.compact .parallax-image-header {
+    display: none;
+  }
+</style>
+
 <Layout title={frontmatter.title}>
   <div
+    class="parallax-image-header"
     style={`view-transition-name: cover-image-${frontmatter.id}; display:block;`}
   >
     {

--- a/src/layouts/_Navbar.svelte
+++ b/src/layouts/_Navbar.svelte
@@ -7,6 +7,7 @@
     NavHamburger,
     DarkMode,
   } from "flowbite-svelte";
+  import CompactControls from "../components/CompactMode/CompactControls.svelte";
   import { onMount } from "svelte";
   import { throttle } from "../helpers/throttle";
   import { navbar } from "../stores/layout";
@@ -97,11 +98,15 @@
             >Github</NavLi
           >
         </NavUl>
-        <DarkMode btnClass="ml-4 text-white" size="lg" />
+        <div class="flex items-center">
+          <DarkMode btnClass="ml-4 text-white" size="lg" />
+          <CompactControls />
+        </div>
       </div>
     {:else}
       <div>
         <DarkMode btnClass="ml-4 text-white" size="lg" />
+        <CompactControls />
         <NavHamburger menuClass="text-white" />
       </div>
       <NavUl

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -33,6 +33,21 @@ const tagsList = posts.reduce((acc, post) => {
 }, []);
 ---
 
+<script>
+  import { compact } from "../stores/compact";
+  compact.subscribe((value) => {
+    if (typeof document !== "undefined") {
+      document.body.classList.toggle("compact", value);
+    }
+  });
+</script>
+
+<style is:global>
+  body.compact .post-cover-image {
+    display: none;
+  }
+</style>
+
 <Layout title="Blog">
   <main class="">
     <section class="">
@@ -123,6 +138,7 @@ const tagsList = posts.reduce((acc, post) => {
                   >
                     <article class="h-fit transform rounded-lg border border-gray-200 bg-white shadow-md transition duration-100 ease-in dark:border-gray-700 dark:bg-gray-800 sm:hover:scale-[102%] lg:hover:scale-105">
                       <div
+                        class="post-cover-image"
                         style={`view-transition-name: cover-image-${post.frontmatter.id};`}
                       >
                         {post.frontmatter.status !== "published" && (

--- a/src/stores/compact.ts
+++ b/src/stores/compact.ts
@@ -1,0 +1,3 @@
+import { writable } from 'svelte/store';
+
+export const compact = writable(false);


### PR DESCRIPTION
This commit introduces a compact mode to the blog. When enabled, it removes the cover images from the blog list and individual blog pages, providing a more streamlined reading experience.

A new Svelte store and component have been created to manage the compact mode state and provide a toggle in the navbar. The blog and post layouts have been updated to conditionally render the cover images based on the compact mode state.